### PR TITLE
Migrate AOP/KE-parameterised examples to v1.1 autocomplete syntax

### DIFF
--- a/B. AOPs/get-ao-for-mie.rq
+++ b/B. AOPs/get-ao-for-mie.rq
@@ -1,15 +1,14 @@
 # title: Get AO for a specific MIE
-# description: Returns the Adverse Outcome linked to a specific Molecular Initiating Event by its identifier URI.
-# category: AOPs
-# param: mie_id|uri|https://identifiers.org/aop.events/18|MIE identifier URI
+# description: Returns the Adverse Outcome linked to a specific Molecular Initiating Event.
+# param: mie_id|autocomplete:keyEvent|18|MIE
 
 SELECT ?MIEwebpage ?MolecularInitiatingEventName ?AOwebpage ?AdverseOutcomeName
 WHERE {
+  BIND(<https://identifiers.org/aop.events/{{mie_id}}> AS ?MIEwebpage)
   ?MIEwebpage dc:identifier ?MIELookup ;
     dc:title ?MolecularInitiatingEventName .
   ?AOPwebpage a aopo:AdverseOutcomePathway ;
     aopo:has_molecular_initiating_event ?MIELookup ;
     aopo:has_adverse_outcome ?AOwebpage .
   ?AOwebpage dc:title ?AdverseOutcomeName .
-  FILTER (?MIEwebpage = <{{mie_id}}>)
 }

--- a/B. AOPs/get-aop-for-ao.rq
+++ b/B. AOPs/get-aop-for-ao.rq
@@ -1,11 +1,10 @@
 # title: Get AOPs for a specific AO
-# description: Returns all Adverse Outcome Pathways that include a specific Adverse Outcome by its identifier URI.
-# category: AOPs
-# param: ao_id|uri|https://identifiers.org/aop.events/1276|AO identifier URI
+# description: Returns all Adverse Outcome Pathways that include a specific Adverse Outcome.
+# param: ao_id|autocomplete:keyEvent|1276|AO
 
 SELECT ?AOP ?AOPTitle
 WHERE {
   ?AOP a aopo:AdverseOutcomePathway ;
     dc:title ?AOPTitle ;
-    aopo:has_adverse_outcome <{{ao_id}}> .
+    aopo:has_adverse_outcome <https://identifiers.org/aop.events/{{ao_id}}> .
 }

--- a/B. AOPs/methods-for-aops.rq
+++ b/B. AOPs/methods-for-aops.rq
@@ -1,20 +1,17 @@
 # title: List methods for AOPs
 # description: Returns Key Events with their applicable species and measurement methods for a specific AOP.
-# category: AOPs
-# param: aop_id|string|AOP 12|AOP identifier
+# param: aop_id|autocomplete:aop|12|AOP
 
 SELECT DISTINCT ?aop ?ke
   (GROUP_CONCAT(DISTINCT ?speciesname; separator=" | ") AS ?speciesnames)
   ?method
 WHERE {
-  ?aop a aopo:AdverseOutcomePathway ;
-    rdfs:label ?aop_id ;
-    aopo:has_key_event ?ke .
+  BIND(aop:{{aop_id}} AS ?aop)
+  ?aop aopo:has_key_event ?ke .
   ?ke ncbitaxon:131567 ?taxon .
   ?taxon a ncbitaxon:131567 ;
     dc:title ?speciesname .
   OPTIONAL { ?ke mmo:0000000 ?method . }
-  VALUES ?aop_id {"{{aop_id}}"}
 }
 GROUP BY ?aop ?ke ?method
 ORDER BY ASC(?aop)

--- a/D. KERs/list-kers-for-aop.rq
+++ b/D. KERs/list-kers-for-aop.rq
@@ -1,0 +1,13 @@
+# title: List KERs in an AOP
+# description: Returns all Key Event Relationships in a specific AOP, with the upstream and downstream Key Event titles for each.
+# param: aop_id|autocomplete:aop|12|AOP
+
+SELECT ?KER ?upstreamKE ?upstreamTitle ?downstreamKE ?downstreamTitle
+WHERE {
+  aop:{{aop_id}} aopo:has_key_event_relationship ?KER .
+  ?KER aopo:has_upstream_key_event ?upstreamKE ;
+       aopo:has_downstream_key_event ?downstreamKE .
+  ?upstreamKE dc:title ?upstreamTitle .
+  ?downstreamKE dc:title ?downstreamTitle .
+}
+ORDER BY ?upstreamKE


### PR DESCRIPTION
## Summary

Light up the new v1.1 autocomplete dropdowns (shipped in marvinm2/AOP-Wiki-Snorql-UI#3) in three existing parameterised examples, and seed the previously-empty `D. KERs/` category.

- `B. AOPs/methods-for-aops.rq` — `aop_id|string|"AOP 12"` → `autocomplete:aop|12`; query rewritten from `rdfs:label` match to `BIND(aop:{{aop_id}})`.
- `B. AOPs/get-ao-for-mie.rq` — `mie_id|uri|<https://identifiers.org/aop.events/18>` → `autocomplete:keyEvent|18`; `FILTER` replaced with `BIND` of the constructed `aop.events:` URI.
- `B. AOPs/get-aop-for-ao.rq` — same pattern as get-ao-for-mie.
- **New** `D. KERs/list-kers-for-aop.rq` — uses `autocomplete:aop` to pick the AOP, lists upstream/downstream KE titles for each `aopo:has_key_event_relationship`.

## Verification

All four queries smoke-tested against `https://aopwiki.rdf.bigcat-bioinformatics.org/sparql` with sample IDs (aop:12, mie:18, ao:1276):

| Query | Sample ID | Rows |
|---|---|---|
| methods-for-aops | aop:12 | 3 |
| get-ao-for-mie | mie:18 | 18 |
| get-aop-for-ao | ao:1276 | 4 |
| list-kers-for-aop | aop:12 | 5 |

Parsed header output verified via `parseRqHeaders()` in the snorql.js v1.1 build — each migrated param produces `type: "autocomplete"` + `autocompleteType: "aop"` / `"keyEvent"` with the correct `defaultValue` and `label`.

## Test plan

- [ ] Pull the AOP-Wiki-Snorql-UI v1.1 image, point `SNORQL_EXAMPLES_REPO` at this branch, open one of the migrated examples — confirm the AOP / KE dropdown renders with live data
- [ ] Pick a different AOP / KE from the dropdown, click Query, confirm results

## Notes

- Three other parameterised examples (`A. Metadata/text-search.rq`, `E. Stressors/stressors-for-ao-searched.rq`, `H. Federated/applicable-to-taxon-tree.rq`) take free-text or taxon IDs and don't fit the current autocomplete types — left as `string` for now. Future work: add `stressor`, `gene`, `chemical`, `taxon` types to the autocomplete registry.
- `# category:` header lines are now dead (parser was removed in v1.1); not stripped here to keep the diff minimal.